### PR TITLE
per-project allocations and fix project resource status

### DIFF
--- a/app/servicers/hardware_servicer.py
+++ b/app/servicers/hardware_servicer.py
@@ -178,7 +178,7 @@ class HardwareServicer(hardware_pb2_grpc.HardwareServiceServicer):
                         "assignedProjects": project_id,
                 },
                 "$set": {"updatedAt": now},
-                }, #"$pull": {"assignedProjects": project_id},#},
+                },
             )
         else:
             _hw_col().update_one(
@@ -189,41 +189,16 @@ class HardwareServicer(hardware_pb2_grpc.HardwareServiceServicer):
                         "checkedOut": -quantity,
                         "allocations.$[alloc].quantity": -quantity
                     },
-                    #"$inc": {"allocations.$[alloc].quantity": -quantity},
                     "$set": {"updatedAt": now},
                 },
                 array_filters=[{"alloc.project_id": project_id}],
             )
-        
-        #checked_out = hw.get("checkedOut", hw["capacity"] - hw["available"])    
-            
-
-        
-        #if checked_out < quantity:
-         #   context.set_code(grpc.StatusCode.FAILED_PRECONDITION)
-          #  context.set_details(
-           #     f"Cannot return {quantity} units – only {checked_out} checked out"
-            #)
-            #return hardware_pb2.Hardware()
 
         now = datetime.now(timezone.utc)
         # We could calculate the new available count here, but since we're doing an atomic update
         # in the database, we can just specify the increments and let MongoDB handle it. The important
         # part is to ensure we don't allow returning more than what's checked out, which we validate above.
         # new_available = hw["available"] + quantity
-        """ new_checked_out = checked_out - quantity
-
-        update_ops: dict = {
-            "$inc": {"available": quantity, "checkedOut": -quantity},
-            "$set": {"updatedAt": now},
-        }
-
-        # If nothing remains checked out for this project, remove it from
-        # the assignedProjects list.
-        if new_checked_out == 0:
-            update_ops["$pull"] = {"assignedProjects": project_id}
-
-        _hw_col().update_one({"_id": hw["_id"]}, update_ops)"""
 
         updated = _hw_col().find_one({"_id": hw["_id"]})
         if not updated:
@@ -239,41 +214,23 @@ class HardwareServicer(hardware_pb2_grpc.HardwareServiceServicer):
         )
         return _doc_to_proto(updated)
     
-    def GetProjectHardware(self, request, context):# define new gRPC method
-        """ Return all hardware sets assigned to a specific project. 
-        This allows clients to query which hardware resources they currently 
-        have checked out. """
-        project_id = request.project_id # extract id from request
+    def GetProjectResourceStatus(self, request, context):
+        """Return the status of all hardware sets assigned to a project.
         
-        if not project_id: # validate input
-            context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
-            context.set_details("project_id is required")
-            return hardware_pb2.HardwareListResponse(hardware_sets=[]) # returns empty response
-        
-        # query MongoDB collection
-        #docs = list(_hw_col().find({"assignedProjects": project_id}))
-        docs = list(_hw_col().find({"allocations.project_id": project_id}))
-        hw_list = [_doc_to_proto(d) for d in docs] # convert to proto messages
-        return hardware_pb2.HardwareListResponse(
-            hardware_sets=hw_list
-        )
-    
-    def GetProjectResourceStatus(self, request, context): # define new gRPC method
-        """ Return the status of a specific hardware set for a project. 
-        This allows clients to check how many units of a hardware set they 
-        currently have checked out. """
-        project_id = request.project_id # get the project id from the request
+        This allows clients to check how many units of each hardware set they
+        currently have checked out, along with availability and capacity info.
+        """
+        project_id = request.project_id
         
         if not project_id:
             context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
             context.set_details("project_id is required")
-            return hardware_pb2.ProjectResourceStatusResponse(resources= []) 
+            return hardware_pb2.ProjectResourceStatusResponse(resources=[])
         
-        #docs = list(_hw_col().find({"assignedProjects": project_id}))
         docs = list(_hw_col().find({"allocations.project_id": project_id}))
         resources = []
         for d in docs:
-            alloc = next (
+            alloc = next(
                 (a for a in d.get("allocations", []) if a.get("project_id") == project_id),
                 None
             )

--- a/app/servicers/hardware_servicer.py
+++ b/app/servicers/hardware_servicer.py
@@ -92,11 +92,30 @@ class HardwareServicer(hardware_pb2_grpc.HardwareServiceServicer):
             return hardware_pb2.Hardware()
 
         now = datetime.now(timezone.utc)
-        _hw_col().update_one(
+        allocations = hw.get("allocations", [])#add allocations
+        has_allocations = any(a.get("project_id") == project_id for a in allocations)
+        
+        if has_allocations:
+            _hw_col().update_one(
+                {"_id": hw["_id"]},
+                { 
+                 "$inc": {
+                        "available": -quantity, 
+                        "checkedOut": quantity,
+                        "allocations.$[alloc].quantity": quantity,
+                },
+                "$addToSet": {"assignedProjects": project_id},
+                "$set": {"updatedAt": now},
+            },
+            array_filters=[{"alloc.project_id": project_id}],   
+        )
+        else:
+            _hw_col().update_one(
             {"_id": hw["_id"]},
             {
                 "$inc": {"available": -quantity, "checkedOut": quantity},
                 "$addToSet": {"assignedProjects": project_id},
+                "$push": {"allocations": {"project_id": project_id, "quantity": quantity}},
                 "$set": {"updatedAt": now},
             },
         )
@@ -131,21 +150,68 @@ class HardwareServicer(hardware_pb2_grpc.HardwareServiceServicer):
             context.set_code(grpc.StatusCode.NOT_FOUND)
             context.set_details(f"Hardware set '{hw_set_id}' not found")
             return hardware_pb2.Hardware()
-
-        checked_out = hw.get("checkedOut", hw["capacity"] - hw["available"])
-        if checked_out < quantity:
+        
+        allocations = hw.get("allocations", [])
+        project_alloc = next((a for a in allocations if a.get("project_id") == project_id), None)
+        if not project_alloc:
+            context.set_code(grpc.StatusCode.FAILED_PRECONDITION)
+            context.set_details(f"Project '{project_id}' has no allocations for '{hw_set_id}'")
+            return hardware_pb2.Hardware()
+        
+        allocated_qty = project_alloc.get("quantity", 0)
+        if allocated_qty < quantity:
             context.set_code(grpc.StatusCode.FAILED_PRECONDITION)
             context.set_details(
-                f"Cannot return {quantity} units – only {checked_out} checked out"
+                f"Cannot return {quantity} units – project only has {allocated_qty} allocated"
             )
             return hardware_pb2.Hardware()
+        
+        now = datetime.now(timezone.utc)
+        
+        if allocated_qty == quantity:
+            _hw_col().update_one(
+                {"_id": hw["_id"]},
+                {
+                    "$inc": {"available": quantity, "checkedOut": -quantity},
+                    "$pull": {
+                        "allocations": {"project_id": project_id},
+                        "assignedProjects": project_id,
+                },
+                "$set": {"updatedAt": now},
+                }, #"$pull": {"assignedProjects": project_id},#},
+            )
+        else:
+            _hw_col().update_one(
+                {"_id": hw["_id"]},
+                {
+                    "$inc": {
+                        "available": quantity,
+                        "checkedOut": -quantity,
+                        "allocations.$[alloc].quantity": -quantity
+                    },
+                    #"$inc": {"allocations.$[alloc].quantity": -quantity},
+                    "$set": {"updatedAt": now},
+                },
+                array_filters=[{"alloc.project_id": project_id}],
+            )
+        
+        #checked_out = hw.get("checkedOut", hw["capacity"] - hw["available"])    
+            
+
+        
+        #if checked_out < quantity:
+         #   context.set_code(grpc.StatusCode.FAILED_PRECONDITION)
+          #  context.set_details(
+           #     f"Cannot return {quantity} units – only {checked_out} checked out"
+            #)
+            #return hardware_pb2.Hardware()
 
         now = datetime.now(timezone.utc)
         # We could calculate the new available count here, but since we're doing an atomic update
         # in the database, we can just specify the increments and let MongoDB handle it. The important
         # part is to ensure we don't allow returning more than what's checked out, which we validate above.
         # new_available = hw["available"] + quantity
-        new_checked_out = checked_out - quantity
+        """ new_checked_out = checked_out - quantity
 
         update_ops: dict = {
             "$inc": {"available": quantity, "checkedOut": -quantity},
@@ -157,7 +223,7 @@ class HardwareServicer(hardware_pb2_grpc.HardwareServiceServicer):
         if new_checked_out == 0:
             update_ops["$pull"] = {"assignedProjects": project_id}
 
-        _hw_col().update_one({"_id": hw["_id"]}, update_ops)
+        _hw_col().update_one({"_id": hw["_id"]}, update_ops)"""
 
         updated = _hw_col().find_one({"_id": hw["_id"]})
         if not updated:
@@ -172,3 +238,57 @@ class HardwareServicer(hardware_pb2_grpc.HardwareServiceServicer):
             project_id,
         )
         return _doc_to_proto(updated)
+    
+    def GetProjectHardware(self, request, context):# define new gRPC method
+        """ Return all hardware sets assigned to a specific project. 
+        This allows clients to query which hardware resources they currently 
+        have checked out. """
+        project_id = request.project_id # extract id from request
+        
+        if not project_id: # validate input
+            context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
+            context.set_details("project_id is required")
+            return hardware_pb2.HardwareListResponse(hardware_sets=[]) # returns empty response
+        
+        # query MongoDB collection
+        #docs = list(_hw_col().find({"assignedProjects": project_id}))
+        docs = list(_hw_col().find({"allocations.project_id": project_id}))
+        hw_list = [_doc_to_proto(d) for d in docs] # convert to proto messages
+        return hardware_pb2.HardwareListResponse(
+            hardware_sets=hw_list
+        )
+    
+    def GetProjectResourceStatus(self, request, context): # define new gRPC method
+        """ Return the status of a specific hardware set for a project. 
+        This allows clients to check how many units of a hardware set they 
+        currently have checked out. """
+        project_id = request.project_id # get the project id from the request
+        
+        if not project_id:
+            context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
+            context.set_details("project_id is required")
+            return hardware_pb2.ProjectResourceStatusResponse(resources= []) 
+        
+        #docs = list(_hw_col().find({"assignedProjects": project_id}))
+        docs = list(_hw_col().find({"allocations.project_id": project_id}))
+        resources = []
+        for d in docs:
+            alloc = next (
+                (a for a in d.get("allocations", []) if a.get("project_id") == project_id),
+                None
+            )
+            if not alloc:
+                continue
+            resources.append(
+                hardware_pb2.ProjectResourceStatus(
+                    hw_set_id=str(d["_id"]),
+                    name=d["hardwareName"],
+                    quantity_checked_out=alloc.get("quantity", 0),
+                    available=d["available"],
+                    capacity=d["capacity"],
+                )
+            )
+        return hardware_pb2.ProjectResourceStatusResponse(resources=resources)
+        
+            
+        

--- a/proto/hardware/v1/hardware.proto
+++ b/proto/hardware/v1/hardware.proto
@@ -14,8 +14,13 @@ import "google/protobuf/timestamp.proto";
 service HardwareService {
     rpc GetHardwareResources (google.protobuf.Empty)  returns (HardwareListResponse) {}
     rpc GetHardware          (GetHardwareRequest)     returns (Hardware)             {}
+    // handles checkout logic including validation, capacity checks 
     rpc RequestHardware      (HardwareRequest)        returns (Hardware)             {}
+    // handles returning hardware and updating availability
     rpc ReturnHardware       (HardwareRequest)        returns (Hardware)             {}
+    rpc GetProjectHardware   (ProjectRequest)         returns (HardwareListResponse) {}
+    // 
+    rpc GetProjectResourceStatus (ProjectRequest)     returns (ProjectResourceStatusResponse) {}
 }
 
 // --- Request Messages ---
@@ -43,4 +48,22 @@ message Hardware {
 
 message HardwareListResponse {
     repeated Hardware hardware_sets = 1;
+}
+
+// project 
+message ProjectRequest {
+    string project_id = 1;
+}
+
+message ProjectResourceStatus {
+    string hw_set_id = 1;
+    string name = 2;
+    // Per project usage
+    uint32 quantity_checked_out = 3;
+    uint32 available = 4; 
+    uint32 capacity = 5;
+}
+
+message ProjectResourceStatusResponse {
+    repeated ProjectResourceStatus resources = 1;
 }

--- a/tests/test_hardware_servicer.py
+++ b/tests/test_hardware_servicer.py
@@ -240,6 +240,7 @@ def test_return_hardware_success_partial_return(servicer, fake_context, mock_col
         "available": 140,  # available before return
         "checkedOut": 60,  # checkedOut before return
         "assignedProjects": ["proj-1"],  # assigned project list
+        "allocations": [{ "project_id": "proj-1", "quantity": 60 }],
         "updatedAt": datetime.now(timezone.utc),  # timestamp
     }  # end pre-return doc
     after = {  # fake post-return DB document
@@ -249,6 +250,7 @@ def test_return_hardware_success_partial_return(servicer, fake_context, mock_col
         "available": 145,  # available increased by 5
         "checkedOut": 55,  # checkedOut decreased by 5
         "assignedProjects": ["proj-1"],  # project still present after partial return
+        "allocations": [{ "project_id": "proj-1", "quantity": 55 }],
         "updatedAt": datetime.now(timezone.utc),  # timestamp
     }  # end post-return doc
 
@@ -259,12 +261,14 @@ def test_return_hardware_success_partial_return(servicer, fake_context, mock_col
     assert fake_context.code is None  # assert success path set no error code
     assert response.available == 145  # assert updated available value
     assert response.checked_out == 55  # assert updated checked_out value
-
+    
     mock_collection.update_one.assert_called_once()  # assert update executed once
     update_filter, update_payload = mock_collection.update_one.call_args.args  # capture update call args
     assert update_filter == {"_id": "mongo-id-1"}  # assert update targeted correct doc
     assert update_payload["$inc"]["available"] == 5  # assert available increment
     assert update_payload["$inc"]["checkedOut"] == -5  # assert checkedOut decrement
+    #
+    assert update_payload["$inc"]["allocations.$[alloc].quantity"] == -5
     assert "$pull" not in update_payload  # assert no project removal on partial return
 
 
@@ -277,13 +281,15 @@ def test_return_hardware_over_return_sets_failed_precondition(servicer, fake_con
         "available": 190,  # currently available
         "checkedOut": 10,  # only 10 checked out
         "assignedProjects": ["proj-1"],  # project assigned
+        "allocations": [{ "project_id": "proj-1", "quantity": 10 }],
         "updatedAt": datetime.now(timezone.utc),  # timestamp
     }  # end mocked
 
     response = servicer.ReturnHardware(request, fake_context)  # call ReturnHardware
 
     assert fake_context.code == grpc.StatusCode.FAILED_PRECONDITION  # assert expected grpc code
-    assert "only 10 checked out" in fake_context.details  # assert expected details content
+    # assert "only 10 checked out" in fake_context.details  # assert expected details content
+    assert "project only has 10 allocated" in fake_context.details
     assert response == hardware_pb2.Hardware()  # assert empty response on failure
     mock_collection.update_one.assert_not_called()  # assert no update attempted
 
@@ -298,6 +304,7 @@ def test_return_hardware_full_return_includes_pull_project(servicer, fake_contex
         "available": 140,  # available before return
         "checkedOut": 10,  # checkedOut before return
         "assignedProjects": ["proj-1"],  # project currently assigned
+        "allocations": [{ "project_id": "proj-1", "quantity": 10 }],
         "updatedAt": datetime.now(timezone.utc),  # timestamp
     }  # end pre-return state
     after = {  # fake post-return state


### PR DESCRIPTION
#35

Updates the Hardware Service to support per-project allocation tracking and enforce project-specific checkout/return constraints.

---

Changes

Data Model
- Added `allocations` field to each hardware document:
  - `{ project_id, quantity }`
- `allocations` is now the source of truth for per-project usage
- `assignedProjects` retained for compatibility

---

Checkout Flow (RequestHardware)
- Decrement `available`
- Increment `checked_out`
- Update allocations:
  - Increment existing project allocation OR
  - Create new allocation entry

---

Return Flow (ReturnHardware)
- Validate project allocation exists
- Reject if return quantity exceeds allocation
- Decrement allocation on partial return
- Remove allocation when quantity reaches zero
- Keep global counters consistent

---

Project-Based Queries
- Updated queries to use allocation-based matching
- `quantity_checked_out` is now derived from allocations

---

API Changes (gRPC)

New RPCs
- `GetProjectHardware(ProjectRequest) -> HardwareListResponse`
- `GetProjectResourceStatus(ProjectRequest) -> ProjectResourceStatusResponse`

New Messages
- `ProjectRequest`
  - `project_id`

- `ProjectResourceStatus`
  - `hw_set_id`
  - `name`
  - `quantity_checked_out`
  - `available`
  - `capacity`

- `ProjectResourceStatusResponse`
  - `repeated resources`

---

Validation

Unit Tests
- 12 / 12 tests passing

---